### PR TITLE
Fix expected arrival to departure

### DIFF
--- a/src/components/Target.vue
+++ b/src/components/Target.vue
@@ -10,7 +10,7 @@
         class="time_num"
       >{{ this.buslist !== "hello" ? (seconds < 10 ? "0" + seconds : seconds) : "" }}</span>
     </span>
-    <span class="estimate_test">&nbsp;후 도착예정</span>
+    <span class="estimate_test">&nbsp;후 출발예정</span>
   </div>
 </template>
 


### PR DESCRIPTION
Changed `도착예정` to  `출발예정`.
This is because the bus actually departs the bus stop at the time written in the timetable. The bus "arrives" about 2-3 min prior to departure.